### PR TITLE
FIX: Patch p4p close to avoid issues with destructor.

### DIFF
--- a/meme/__init__.py
+++ b/meme/__init__.py
@@ -1,2 +1,16 @@
+# Patch p4p close with Python 2.7
+# For more details see: https://github.com/mdavidsaver/p4p/issues/55
+from p4p.client import thread
+
+_p4p_thread_context_close = thread.Context.close
+
+def close(*args, **kwargs):
+    try:
+        _p4p_thread_context_close(*args, **kwargs)
+    except TypeError:
+        pass
+
+thread.Context.close = close
+
 from . import names
 from . import archive


### PR DESCRIPTION
Related to CATER 147200(TEC)

And also related to: https://github.com/mdavidsaver/p4p/issues/55

Fix to p4p will be added soon. This will allow us to no longer have the issue at SLAC while the new p4p version is not available.

