### PR TITLE
Update split quads

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,10 +36,10 @@ Model
 -----
 Interacting with the model takes an object oriented approach.  To get model
 data, first make an instance of the `Model` class, then call its methods to
-get the data you are interested in:
+get the data you are interested in. Model must be given a path.The path can be "CU_HXR", "CU_SXR","CU_SPEC", "SC_DIAG0", "SC_BSYD", "SC_HXR", "SC_SXR", or "FACET2E". It can also be givena model_source (for FACET this must be LUCRETIA. The default is BMAD).
 
 >>> from meme.model import Model
->>> m = Model()
+>>> m = Model('CU_HXR','BMAD')
 >>> m.get_rmat('BPMS:LI24:801')
 <6x6 np.ndarray>
 
@@ -51,7 +51,7 @@ you'd like to refresh the data for an existing instance, you can do that by
 calling `Model.refresh_all()`:
 
 >>> from meme.model import Model
->>> m = Model()
+>>> m = Model('CU_HXR')
 >>> twiss = m.get_twiss('QUAD:LTU1:440')
 >>> m.refresh_all() #The beam energy has changed and you want a new model.
 >>> new_twiss = m.get_twiss('QUAD:LTU1:440')


### PR DESCRIPTION
Fixing issue where FACET2E LUCRETIA model can't read quads since they're split elements:

Updated meme.model. Changed _get_indices_for_names() to handle the case where we have two elements with the same name. Previously, _get_indices_for_names() had expected them to have suffic https://github.com/slaclab/meme/issues/1 and https://github.com/slaclab/meme/pull/2 (where https://github.com/slaclab/meme/pull/2 started in the middle of the device). Now, if it doesn't find those suffixes, then it assigns the first and last device by s-position.

I also changed the twiss structure to include "s" and "z" explicitly (they were already broadcast, just not represented internally to meme).

Then I updated the readme for more information about beampath.